### PR TITLE
hotfix-maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,11 @@
   <groupId>cilabo.MoFGBML</groupId>
   <artifactId>MoFGBML</artifactId>
   <version>23.0.0-SNAPSHOT</version>
+
   <build>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>srctest</testSourceDirectory>
+
     <resources>
       <resource>
         <directory>src</directory>
@@ -14,7 +16,9 @@
         </excludes>
       </resource>
     </resources>
+
     <plugins>
+
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.2</version>
@@ -22,13 +26,32 @@
           <archive>
             <manifest>
               <mainClass>cilabo.labo.developing.fan2021.FAN2021_Main</mainClass>
+              <classpathPrefix>dependency/</classpathPrefix>>
               <addClasspath>true</addClasspath>
               <addExtensions>true</addExtensions>
-              <packageName>main</packageName>
             </manifest>
           </archive>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.5.1</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/dependency/</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
@@ -37,8 +60,11 @@
           <target>1.8</target>
         </configuration>
       </plugin>
+
     </plugins>
+
   </build>
+
   <dependencies>
   	<dependency>
   		<groupId>org.apache.commons</groupId>
@@ -105,6 +131,7 @@
   		<groupId>org.junit.jupiter</groupId>
   		<artifactId>junit-jupiter-api</artifactId>
   		<version>5.7.0</version>
+  		<scope>test</scope>
   	</dependency>
   	<dependency>
   		<groupId>nz.ac.waikato.cms.weka</groupId>
@@ -112,4 +139,5 @@
   		<version>3.9.1</version>
   	</dependency>
   </dependencies>
+
 </project>

--- a/srctest/cilabo/gbml/operator/crossover/HybridGBMLcrossoverTest.java
+++ b/srctest/cilabo/gbml/operator/crossover/HybridGBMLcrossoverTest.java
@@ -55,8 +55,8 @@ public class HybridGBMLcrossoverTest {
 				 											problem.getConsequentFactory());
 		String doCrossover = michiganX.doCrossover(1.0, parent).get(0).toString();
 
-		System.out.println("doCrossover");
-		System.out.println(doCrossover);
+//		System.out.println("doCrossover");
+//		System.out.println(doCrossover);
 	}
 
 	@Test
@@ -110,9 +110,9 @@ public class HybridGBMLcrossoverTest {
 																michiganX, pittsburghX);
 
 		List<IntegerSolution> offspring = crossover.execute(solutions);
-		System.out.println(offspring);
+//		System.out.println(offspring);
 
 		michiganProblem.michiganEvaluate(((PittsburghSolution)offspring.get(0)).getMichiganPopulation());
-		System.out.println();
+//		System.out.println();
 	}
 }

--- a/srctest/cilabo/gbml/operator/crossover/PittsburghCrossoverTest.java
+++ b/srctest/cilabo/gbml/operator/crossover/PittsburghCrossoverTest.java
@@ -41,6 +41,6 @@ public class PittsburghCrossoverTest {
 		double probability = 1.0;
 		PittsburghCrossover crossover = new PittsburghCrossover(probability);
 		List<IntegerSolution> offspring = crossover.execute(solutions);
-		System.out.println(offspring);
+//		System.out.println(offspring);
 	}
 }

--- a/srctest/cilabo/gbml/operator/crossover/UniformCrossoverTest.java
+++ b/srctest/cilabo/gbml/operator/crossover/UniformCrossoverTest.java
@@ -31,31 +31,31 @@ public class UniformCrossoverTest {
 		IntegerSolution parent2 = problem.createSolution();
 		String p1 = parent1.toString();
 		String p2 = parent2.toString();
-		System.out.println("[original]");
-		System.out.print(p1);
-		System.out.println(p2);
+//		System.out.println("[original]");
+//		System.out.print(p1);
+//		System.out.println(p2);
 
 		List<IntegerSolution> solutions = new ArrayList<>();
 		solutions.add(parent1);
 		solutions.add(parent2);
 
 		// Case 1: don't crossover
-		System.out.println("[Case 1: don't crossover]");
+//		System.out.println("[Case 1: don't crossover]");
 		double probability = 0.0;
 		UniformCrossover crossover = new UniformCrossover(probability);
 		List<IntegerSolution> offspring = crossover.execute(solutions);
-		System.out.print(p1);
-		System.out.print(p2);
-		System.out.println(offspring.get(0));
+//		System.out.print(p1);
+//		System.out.print(p2);
+//		System.out.println(offspring.get(0));
 //		assertEquals(p1, offspring.get(0).toString());
 
 		// Case 2: do fully crossover
-		System.out.println("[Case 2: do fully crossover]");
+//		System.out.println("[Case 2: do fully crossover]");
 		probability = 1.0;
 		crossover = new UniformCrossover(probability);
 		offspring = crossover.execute(solutions);
-		System.out.print(p1);
-		System.out.print(p2);
-		System.out.println(offspring.get(0));
+//		System.out.print(p1);
+//		System.out.print(p2);
+//		System.out.println(offspring.get(0));
 	}
 }

--- a/srctest/cilabo/gbml/operator/heuristic/HeuristicRuleGenerationTest.java
+++ b/srctest/cilabo/gbml/operator/heuristic/HeuristicRuleGenerationTest.java
@@ -36,7 +36,7 @@ public class HeuristicRuleGenerationTest {
 		for(int i = 0; i < num; i++) {
 
 			Antecedent antecedent = generator.heuristicRuleGeneration(train.getPattern(i));
-			System.out.println(antecedent);
+//			System.out.println(antecedent);
 		}
 
 

--- a/srctest/cilabo/gbml/operator/mutation/PittsburghMutationTest.java
+++ b/srctest/cilabo/gbml/operator/mutation/PittsburghMutationTest.java
@@ -32,13 +32,13 @@ public class PittsburghMutationTest {
 		// Solution
 		IntegerSolution solution = problem.createSolution();
 		String beforeString = solution.toString();
-		System.out.println(beforeString);
+//		System.out.println(beforeString);
 
 		MutationOperator<IntegerSolution> mutation = new PittsburghMutation(problem.getKnowledge(), train);
 		mutation.execute(solution);
 
 		String afterString = solution.toString();
-		System.out.println(afterString);
+//		System.out.println(afterString);
 	}
 
 }

--- a/srctest/cilabo/gbml/operator/mutation/RuleMutationTest.java
+++ b/srctest/cilabo/gbml/operator/mutation/RuleMutationTest.java
@@ -28,15 +28,15 @@ public class RuleMutationTest {
 
 		// Solution
 		IntegerSolution solution = problem.createSolution();
-		System.out.println("[original]");
-		System.out.println(solution.toString());
+//		System.out.println("[original]");
+//		System.out.println(solution.toString());
 
 		// Operator
 		double mutationProbability = 1.0 / (double)train.getDataSize();
 		mutationProbability = 1.0;
 		MichiganMutation mutation = new MichiganMutation(mutationProbability, knowledge, train);
 		mutation.execute(solution);
-		System.out.println("[new solution]");
-		System.out.println(solution.toString());
+//		System.out.println("[new solution]");
+//		System.out.println(solution.toString());
 	}
 }


### PR DESCRIPTION
Mavenのビルドで依存関係ライブラリがコピーされない問題を解決しました．