### PR TITLE
WIP: メイン関数の下準備【Two-stage】

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ copy/
 python/
 results/
 doc/
+dataset/german/
 
 .DS_Store
 jMetal.log

--- a/src/cilabo/gbml/algorithm/HybridMoFGBMLwithNSGAII.java
+++ b/src/cilabo/gbml/algorithm/HybridMoFGBMLwithNSGAII.java
@@ -295,4 +295,9 @@ public class HybridMoFGBMLwithNSGAII<S extends Solution<?>> extends AbstractEvol
 		return this;
 	}
 
+	public HybridMoFGBMLwithNSGAII<S> setEvaluations(int evaluations) {
+		this.evaluations = evaluations;
+		return this;
+	}
+
 }

--- a/src/cilabo/labo/developing/twostage/AccuracyOrientedReplacement.java
+++ b/src/cilabo/labo/developing/twostage/AccuracyOrientedReplacement.java
@@ -1,5 +1,10 @@
 package cilabo.labo.developing.twostage;
 
+import java.util.List;
+
+import org.uma.jmetal.component.replacement.Replacement;
+import org.uma.jmetal.solution.Solution;
+
 /**
  * org.uma.jmetal.component.replacement.Replacementをimplements
  *
@@ -14,6 +19,12 @@ package cilabo.labo.developing.twostage;
  *
  * これは1stステージのReplacementとして使用される．
  */
-public class AccuracyOrientedReplacement {
+public class AccuracyOrientedReplacement<S extends Solution<?>> implements Replacement<S> {
+
+	//TODO 未実装
+	@Override
+	public List<S> replace(List<S> currentList, List<S> offspringList) {
+		return null;
+	}
 
 }

--- a/src/cilabo/labo/developing/twostage/PittsburghCrossoverComplexOriented.java
+++ b/src/cilabo/labo/developing/twostage/PittsburghCrossoverComplexOriented.java
@@ -1,5 +1,23 @@
 package cilabo.labo.developing.twostage;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.uma.jmetal.operator.crossover.CrossoverOperator;
+import org.uma.jmetal.solution.integersolution.IntegerSolution;
+import org.uma.jmetal.util.JMetalException;
+import org.uma.jmetal.util.checking.Check;
+import org.uma.jmetal.util.pseudorandom.BoundedRandomGenerator;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
+import org.uma.jmetal.util.pseudorandom.RandomGenerator;
+
+import cilabo.fuzzy.classifier.RuleBasedClassifier;
+import cilabo.gbml.solution.PittsburghSolution;
+import cilabo.main.Consts;
+import cilabo.utility.GeneralFunctions;
+import cilabo.utility.Random;
+
 /**
  * cilabo.gbml.operator.crossover.PittsburghCrossover を参考に作成
  * CrossoverOperatorをimplements
@@ -24,6 +42,194 @@ package cilabo.labo.developing.twostage;
  *     ※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※※
  *
  */
-public class PittsburghCrossoverComplexOriented {
+public class PittsburghCrossoverComplexOriented implements CrossoverOperator<IntegerSolution> {
+	private double crossoverProbability;
+	private RandomGenerator<Double> crossoverRandomGenerator;
+	BoundedRandomGenerator<Integer> selectRandomGenerator;
 
+	/** Constructor */
+	public PittsburghCrossoverComplexOriented(double crossoverProbability) {
+		this(
+			crossoverProbability,
+			() -> JMetalRandom.getInstance().nextDouble(),
+			(a, b) -> JMetalRandom.getInstance().nextInt(a, b));
+	}
+
+	/** Constructor */
+	public PittsburghCrossoverComplexOriented(
+			double crossoverProbability, RandomGenerator<Double> randomGenerator) {
+		this(
+			crossoverProbability,
+			randomGenerator,
+			BoundedRandomGenerator.fromDoubleToInteger(randomGenerator));
+	}
+
+	/** Constructor */
+	public PittsburghCrossoverComplexOriented(
+			double crossoverProbability,
+			RandomGenerator<Double> crossoverRandomGenerator,
+			BoundedRandomGenerator<Integer> selectRandomGenerator) {
+		if(crossoverProbability < 0) {
+			throw new JMetalException("Crossover probability is negative: " + crossoverProbability);
+		}
+		this.crossoverProbability = crossoverProbability;
+		this.crossoverRandomGenerator = crossoverRandomGenerator;
+		this.selectRandomGenerator = selectRandomGenerator;
+	}
+
+	/* Getter */
+	@Override
+	public double getCrossoverProbability() {
+		return this.crossoverProbability;
+	}
+
+	/* Setter */
+	public void setCrossoverProbability(double crossoverProbability) {
+		this.crossoverProbability = crossoverProbability;
+	}
+
+	@Override
+	public int getNumberOfRequiredParents() {
+		return 2;
+	}
+
+	@Override
+	public int getNumberOfGeneratedChildren() {
+		return 1;
+	}
+
+	@Override
+	public List<IntegerSolution> execute(List<IntegerSolution> solutions) {
+		Check.isNotNull(solutions);
+		Check.that(solutions.size() == 2, "There must be two parents instead of " + solutions.size());
+		return doCrossover(crossoverProbability, solutions.get(0), solutions.get(1));
+	}
+
+	/**
+	 * 後件部の学習はここでは行わない
+	 * @param probability
+	 * @param _parent1
+	 * @param _parent2
+	 * @return
+	 */
+	public List<IntegerSolution> doCrossover(double probability, IntegerSolution _parent1, IntegerSolution _parent2) {
+		// Cast IntegerSolution to PittsburghSolution
+		PittsburghSolution parent1 = (PittsburghSolution)_parent1;
+		PittsburghSolution parent2 = (PittsburghSolution)_parent2;
+
+		List<IntegerSolution> offspring = new ArrayList<>();
+
+		/* Do crossover */
+		if(crossoverRandomGenerator.getRandomValue() < probability) {
+			/** Number of rules inherited from parent1.  */
+			int N1 = selectRandomGenerator.getRandomValue(0, parent1.getMichiganPopulation().size());
+			/** Number of rules inherited from parent2.  */
+			int N2 = selectRandomGenerator.getRandomValue(0, parent2.getMichiganPopulation().size());
+
+			// Reduciong excess of rules
+			if((N1+N2) > Consts.MAX_RULE_NUM) {
+				int delNum = (N1+N2) - Consts.MAX_RULE_NUM;
+				for(int i = 0; i < delNum; i++) {
+					if( N1 > 0 && N2 > 0){
+						if(selectRandomGenerator.getRandomValue(0, 1) == 0) {
+							N1--;
+						}
+						else {
+							N2--;
+						}
+					}
+					else if(N1 == 0 && N2 > 0) {
+						N2--;
+					}
+					else if(N1 > 0 && N2 == 0) {
+						N1--;
+					}
+					else {
+						break;
+					}
+				}
+			}
+			// Replenishing lack of number of rules
+			if((N1+N2) < Consts.MIN_RULE_NUM) {
+				int lackNum = Consts.MIN_RULE_NUM - (N1+N2);
+				for(int i = 0; i < lackNum; i++) {
+					if( N1 < parent1.getMichiganPopulation().size() &&
+						N2 < parent2.getMichiganPopulation().size())
+					{
+						if(selectRandomGenerator.getRandomValue(0, 1) == 0) {
+							N1++;
+						}
+						else {
+							N2++;
+						}
+					}
+					else if(N1 >= parent1.getMichiganPopulation().size() &&
+							N2 < parent2.getMichiganPopulation().size()) {
+						N2++;
+					}
+					else if(N1 < parent1.getMichiganPopulation().size() &&
+							N2 >= parent2.getMichiganPopulation().size()) {
+						N1++;
+					}
+					else {
+						break;
+					}
+				}
+			}
+
+			// Crossover
+			List<IntegerSolution> michiganPopulation1 = new ArrayList<>();	// offspring 1
+			List<IntegerSolution> michiganPopulation2 = new ArrayList<>();	// offspring 2
+			// Select inherited rules for offspring 1
+			int ruleNum = ((RuleBasedClassifier)parent1.getClassifier()).getRuleNum();
+			Integer[] index1 = GeneralFunctions.samplingWithout(ruleNum, N1, Random.getInstance().getGEN());
+			ruleNum = ((RuleBasedClassifier)parent2.getClassifier()).getRuleNum();
+			Integer[] index2 = GeneralFunctions.samplingWithout(ruleNum, N2, Random.getInstance().getGEN());
+
+			// Inheriting
+			// from parint1
+			for(int i = 0; i < parent1.getMichiganPopulation().size(); i++) {
+				if(Arrays.asList(index1).contains(i)) {
+					michiganPopulation1.add((IntegerSolution)parent1.getMichiganPopulation().get(i).copy());
+				}
+				else {
+					michiganPopulation2.add((IntegerSolution)parent1.getMichiganPopulation().get(i).copy());
+				}
+			}
+			// from parint2
+			for(int i = 0; i < parent2.getMichiganPopulation().size(); i++) {
+				if(Arrays.asList(index2).contains(i)) {
+					michiganPopulation1.add((IntegerSolution)parent2.getMichiganPopulation().get(i).copy());
+				}
+				else {
+					michiganPopulation2.add((IntegerSolution)parent2.getMichiganPopulation().get(i).copy());
+				}
+			}
+
+			List<IntegerSolution> manyRules;
+			if(michiganPopulation1.size() >= michiganPopulation2.size()) {
+				manyRules = michiganPopulation1;
+			}
+			else {
+				manyRules = michiganPopulation2;
+			}
+
+			PittsburghSolution child = new PittsburghSolution(
+										parent1.getBounds(),
+										parent1.getNumberOfObjectives(),
+										manyRules,
+										((RuleBasedClassifier)parent1.getClassifier()).getClassification());
+			offspring.clear();
+			offspring.add(child);
+		}
+		/* Don't crossover */
+		else {
+			offspring.add(parent1.copy());
+			offspring.add(parent2.copy());
+			int index = selectRandomGenerator.getRandomValue(0,  1);
+			offspring.remove(index);
+		}
+
+		return offspring;
+	}
 }

--- a/src/cilabo/labo/developing/twostage/PopulationCopyCreation.java
+++ b/src/cilabo/labo/developing/twostage/PopulationCopyCreation.java
@@ -10,7 +10,6 @@ import org.uma.jmetal.solution.Solution;
  * 2ndステージの初期個体群とすることで，
  * 疑似的にスムースな探索の流れを実現させる．
  *
- *
  * インスタンス生成時に必ず個体群のListを受け取る
  * create()は，その時受け取った個体群Listをそのまま返す．
  */

--- a/src/cilabo/labo/developing/twostage/PopulationCopyCreation.java
+++ b/src/cilabo/labo/developing/twostage/PopulationCopyCreation.java
@@ -1,0 +1,29 @@
+package cilabo.labo.developing.twostage;
+
+import java.util.List;
+
+import org.uma.jmetal.component.initialsolutioncreation.InitialSolutionsCreation;
+import org.uma.jmetal.solution.Solution;
+
+/**
+ * 1stステージ終了時の個体群を
+ * 2ndステージの初期個体群とすることで，
+ * 疑似的にスムースな探索の流れを実現させる．
+ *
+ *
+ * インスタンス生成時に必ず個体群のListを受け取る
+ * create()は，その時受け取った個体群Listをそのまま返す．
+ */
+public class PopulationCopyCreation<S extends Solution<?>> implements InitialSolutionsCreation<S> {
+	  List<S> population;
+
+	  public PopulationCopyCreation(List<S> population) {
+		  this.population = population;
+	  }
+
+	  @Override
+	  public List<S> create() {
+		  return this.population;
+	  }
+
+}

--- a/src/cilabo/labo/developing/twostage/SecondStageAlgorithm.java
+++ b/src/cilabo/labo/developing/twostage/SecondStageAlgorithm.java
@@ -8,6 +8,8 @@ package cilabo.labo.developing.twostage;
  * 2ndステージの初期個体群は1stの結果から始めたい
  * -> createInitialPopulation()の中身を書き換えるのはどうか？
  */
+	//TODO 今までのMoFGBMLをそのまま使うので，このクラスは必要ない可能性大．
+	//TODO
 public class SecondStageAlgorithm {
 
 }

--- a/src/cilabo/labo/developing/twostage/TwoStage_Main.java
+++ b/src/cilabo/labo/developing/twostage/TwoStage_Main.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.uma.jmetal.component.initialsolutioncreation.InitialSolutionsCreation;
 import org.uma.jmetal.component.termination.Termination;
 import org.uma.jmetal.component.termination.impl.TerminationByEvaluations;
 import org.uma.jmetal.operator.crossover.CrossoverOperator;
@@ -122,20 +123,76 @@ public class TwoStage_Main {
 	public static void twoStageMoFGBML(DataSet train, DataSet test) {
 		String sep = File.separator;
 
+
+		//TODO 仮置き
+		List<IntegerSolution> population = null;
+		int nowEvaluations = 0;
+
+		//TODO 1stステージの実装
+		/* ======================================= */
+		/* == 1st Stage                         == */
+		/* ======================================= */
+
+		/* ======================================= */
+
+
+		/* ======================================= */
+		/* == 2nd Stage                         == */
+		/* ======================================= */
+		HybridMoFGBMLwithNSGAII<IntegerSolution> secondAlgorithm = make2ndStageAlgorithm(train, test);
+
+		/* Set current population as the initial population for 2nd stage */
+		InitialSolutionsCreation<IntegerSolution> initialSolutionsCreationForSecond = new PopulationCopyCreation<>(population);
+		secondAlgorithm.setInitialSolutionsCreation(initialSolutionsCreationForSecond);
+
+		/* Set current number of evaluations */
+		secondAlgorithm.setEvaluations(nowEvaluations);
+
+		/* === GA RUN === */
+		secondAlgorithm.run();
+		/* ============== */
+		/* ======================================= */
+
+		/* Non-dominated solutions in final generation */
+		List<IntegerSolution> nonDominatedSolutions = secondAlgorithm.getResult();
+	    new SolutionListOutput(nonDominatedSolutions)
+        	.setVarFileOutputContext(new DefaultFileOutputContext(Consts.EXPERIMENT_ID_DIR+sep+"VAR.csv", ","))
+        	.setFunFileOutputContext(new DefaultFileOutputContext(Consts.EXPERIMENT_ID_DIR+sep+"FUN.csv", ","))
+        	.print();
+
+	    // Test data
+	    ArrayList<String> strs = new ArrayList<>();
+	    String str = "pop,test";
+	    strs.add(str);
+
+	    Metric metric = new ErrorRate();
+	    for(int i = 0; i < nonDominatedSolutions.size(); i++) {
+	    	IntegerSolution solution = nonDominatedSolutions.get(i);
+	    	Classifier classifier = ((PittsburghSolution)solution).getClassifier();
+	    	double errorRate = (double)metric.metric(classifier, test);
+
+	    	str = String.valueOf(i);
+	    	str += "," + errorRate;
+	    	strs.add(str);
+	    }
+	    String fileName = Consts.EXPERIMENT_ID_DIR + sep + "results.csv";
+	    Output.writeln(fileName, strs, false);
+
+		return;
+	}
+
+	public static HybridMoFGBMLwithNSGAII<IntegerSolution> make2ndStageAlgorithm(DataSet train, DataSet test) {
 		/* MOP: Multi-objective Optimization Problem */
 		MOP1<IntegerSolution> problem = new MOP1<>(train);
 		problem.setClassification(new SingleWinnerRuleSelection());
 
 		/* Crossover: Hybrid-style GBML specific crossover operator. */
 		double crossoverProbability = 1.0;
+
 		/* Michigan operation */
 		CrossoverOperator<IntegerSolution> michiganX = new MichiganOperation(Consts.MICHIGAN_CROSS_RT,
 																			 problem.getKnowledge(),
 																			 problem.getConsequentFactory());
-		/* ここから -> ************************************************* */
-		/* TODO
-		 * HybridGBMLcrossoverに渡すpittsburghXは，PittsburghCrossoverComplexOrientedに変更
-		 */
 		/* Pittsburgh operation */
 		CrossoverOperator<IntegerSolution> pittsburghX = new PittsburghCrossover(Consts.PITTSBURGH_CROSS_RT);
 		/* ここまで <- ********************************************************* */
@@ -166,36 +223,7 @@ public class TwoStage_Main {
 		EvaluationObserver evaluationObserver = new EvaluationObserver(Consts.outputFrequency);
 		algorithm.getObservable().register(evaluationObserver);
 
-		/* === GA RUN === */
-		algorithm.run();
-		/* ============== */
-
-		/* Non-dominated solutions in final generation */
-		List<IntegerSolution> nonDominatedSolutions = algorithm.getResult();
-	    new SolutionListOutput(nonDominatedSolutions)
-        	.setVarFileOutputContext(new DefaultFileOutputContext(Consts.EXPERIMENT_ID_DIR+sep+"VAR.csv", ","))
-        	.setFunFileOutputContext(new DefaultFileOutputContext(Consts.EXPERIMENT_ID_DIR+sep+"FUN.csv", ","))
-        	.print();
-
-	    // Test data
-	    ArrayList<String> strs = new ArrayList<>();
-	    String str = "pop,test";
-	    strs.add(str);
-
-	    Metric metric = new ErrorRate();
-	    for(int i = 0; i < nonDominatedSolutions.size(); i++) {
-	    	IntegerSolution solution = nonDominatedSolutions.get(i);
-	    	Classifier classifier = ((PittsburghSolution)solution).getClassifier();
-	    	double errorRate = (double)metric.metric(classifier, test);
-
-	    	str = String.valueOf(i);
-	    	str += "," + errorRate;
-	    	strs.add(str);
-	    }
-	    String fileName = Consts.EXPERIMENT_ID_DIR + sep + "results.csv";
-	    Output.writeln(fileName, strs, false);
-
-		return;
+		return algorithm;
 	}
 
 

--- a/src/cilabo/labo/developing/twostage/TwoStage_Main.java
+++ b/src/cilabo/labo/developing/twostage/TwoStage_Main.java
@@ -51,7 +51,7 @@ public class TwoStage_Main {
 		System.out.println("main: " + TwoStage_Main.class.getCanonicalName());
 		System.out.println("version: " + version);
 		System.out.println();
-		System.out.println("Algorithm: ???");
+		System.out.println("Algorithm: Two-stage for accuracy-oriented FGBML");
 		System.out.println("EMOA: NSGA-II");
 		System.out.println();
 		/* ********************************************************* */

--- a/srctest/cilabo/gbml/operator/crossover/PittsburghCrossoverComplexOrientedTest.java
+++ b/srctest/cilabo/gbml/operator/crossover/PittsburghCrossoverComplexOrientedTest.java
@@ -1,0 +1,49 @@
+package cilabo.gbml.operator.crossover;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.uma.jmetal.solution.integersolution.IntegerSolution;
+import org.uma.jmetal.util.pseudorandom.JMetalRandom;
+
+import cilabo.data.DataSet;
+import cilabo.fuzzy.classifier.operator.classification.Classification;
+import cilabo.fuzzy.classifier.operator.classification.factory.SingleWinnerRuleSelection;
+import cilabo.gbml.problem.impl.pittsburgh.MOP1;
+import cilabo.labo.developing.twostage.PittsburghCrossoverComplexOriented;
+import cilabo.utility.Input;
+
+public class PittsburghCrossoverComplexOrientedTest {
+
+
+	@Test
+	public void testExecute() {
+		String sep = File.separator;
+		// Load "Pima" dataset
+		String dataName = "dataset" + sep + "pima" + sep + "a0_0_pima-10tra.dat";
+		DataSet train = new DataSet();
+		Input.inputSingleLabelDataSet(train, dataName);
+
+		JMetalRandom.getInstance().setSeed(4);
+
+		//Problem
+		MOP1<IntegerSolution> problem = new MOP1<>(train);
+		Classification classification = new SingleWinnerRuleSelection();
+		problem.setClassification(classification);
+
+		// Parents
+		IntegerSolution parent1 = problem.createSolution();
+		IntegerSolution parent2 = problem.createSolution();
+		List<IntegerSolution> solutions = new ArrayList<>();
+		solutions.add(parent1);
+		solutions.add(parent2);
+
+		// Crossover
+		double probability = 1.0;
+		PittsburghCrossoverComplexOriented crossover = new PittsburghCrossoverComplexOriented(probability);
+		List<IntegerSolution> offspring = crossover.execute(solutions);
+
+	}
+}


### PR DESCRIPTION
もう少し実装しやすいように，メイン関数の下準備をしました．

特に，2ndステージは今までと全く同じMoFGBMLを使用するということで，基本的な2ndステージの流れをメイン関数に実装しました．

1stステージの（疑似的な）最終個体群を，2ndステージの（疑似的な）初期個体群として渡すようにしています．  
また，1stステージで消費した評価個体数を，2ndステージに引き継ぐようにしています．

今までと全く同じMoFGBMLということなので，恐らく「SecondStageAlgorithm.java」は消しても良さそうな感じです．