### PR TITLE
Fairness PPV_diffの計算の変更

### DIFF
--- a/src/cilabo/metric/fairness/PositivePredictiveValuesDifference.java
+++ b/src/cilabo/metric/fairness/PositivePredictiveValuesDifference.java
@@ -56,18 +56,13 @@ public class PositivePredictiveValuesDifference implements Metric {
 				continue;
 			}
 
-			// "y = 0"でなければ次のパターン
-			if(trueClass.getClassLabel() != 0) {
-				continue;
-			}
-
 			// Sensitive attribute value
 			int a = pattern.getA();
 			sizeForSensitive[a]++;
 
 
-			// "y^ = 1"を判定
-			if(classifiedClass.getClassLabel() == 1) {
+			// "y = 1"を判定
+			if(trueClass.getClassLabel() != 0) {
 				countForSensitive[a]++;
 			}
 		}


### PR DESCRIPTION
issueに挙げた問題の解決．
PPV_diff の計算式の変更．
具体的には，第一項  P| y = 1 | y^ = 1, a = 0| の計算を y = 1 ⋀ y^ = 1 ⋀ a = 0 のパターン数 / y^ = 1 ⋀ a = 0 のパターン数となるように変更しました． 

close #16