### PR TITLE
Re: Fairness PPV_diffの計算の変更

### DIFF
--- a/src/cilabo/metric/fairness/PositivePredictiveValuesDifference.java
+++ b/src/cilabo/metric/fairness/PositivePredictiveValuesDifference.java
@@ -50,25 +50,22 @@ public class PositivePredictiveValuesDifference implements Metric {
 			// Classification
 			ClassLabel classifiedClass = classifier.classify(pattern.getInputVector()).getConsequent().getClassLabel();
 
-			// "y^ = 1"でない or Rejected ならば 次のパターン
-			if( classifiedClass.getClass() == RejectedClassLabel.class ||
-				classifiedClass.getClassLabel() != 1 ) {
-				continue;
-			}
-
-			// "y = 0"でなければ次のパターン
-			if(trueClass.getClassLabel() != 0) {
+			// Rejected ならば 次のパターン
+			if(classifiedClass.getClass() == RejectedClassLabel.class) {
 				continue;
 			}
 
 			// Sensitive attribute value
 			int a = pattern.getA();
-			sizeForSensitive[a]++;
 
-
-			// "y^ = 1"を判定
+			//分母
 			if(classifiedClass.getClassLabel() == 1) {
-				countForSensitive[a]++;
+				sizeForSensitive[a]++;
+
+				//分子
+				if(trueClass.getClassLabel() == 1) {
+					countForSensitive[a]++;
+				}
 			}
 		}
 


### PR DESCRIPTION
#17 のプルリクエストに関する内容で、 
#16 のissueの返信で提案した
https://github.com/CI-labo-OPU/MoFGBML/blob/812b55f67a6a4c7d58ffa745da3fc7e4647b129f/src/cilabo/metric/fairness/PositivePredictiveValuesDifference.java#L47-L73
のforループ部分の変更が[差分](https://github.com/CI-labo-OPU/MoFGBML/pull/18/files)で見やすいようにプルリクエストを作りました。